### PR TITLE
Add ClawBench to computer-use benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1057,6 +1057,7 @@ To make the notion of "horizon" concrete, [METR](https://arxiv.org/abs/2503.1449
 - **`ICLR 2025`** AndroidWorld: A Dynamic Benchmarking Environment for Autonomous Agents. [[code](https://github.com/google-research/android_world)]
 - **`ACL 2025`** AndroidLab: Training and Systematic Benchmarking of Android Autonomous Agents. [[code](https://github.com/THUDM/Android-Lab)]
 - **`arXiv 2025`** PointArena: Probing Multimodal Grounding Through Language-Guided Pointing. [[code](https://arxiv.org/abs/2505.09990)]
+- **`arXiv 2026`** ClawBench: A real-world browser-agent benchmark spanning 153 everyday tasks across 144 live production websites, with request-interception safety and layered execution traces.<br/>![venue](https://img.shields.io/badge/arXiv%202026-555?style=flat-square) [![arXiv](https://img.shields.io/badge/arXiv-2604.08523-b31b1b?style=flat-square\&logo=arxiv\&logoColor=white)](https://arxiv.org/abs/2604.08523) [![stars](https://img.shields.io/github/stars/reacher-z/ClawBench?style=flat-square\&logo=github\&label=%E2%98%85\&color=444)](https://github.com/reacher-z/ClawBench)
 
 
 ### Multimodal Agents


### PR DESCRIPTION
## Summary\n\nAdds ClawBench to the **Computer Use** subsection of **Benchmarks and Resources**.\n\nClawBench evaluates browser agents on 153 everyday tasks across 144 live production websites, using request-level interception to prevent side effects and providing layered execution traces for analysis.\n\n- Paper: https://arxiv.org/abs/2604.08523\n- Project: https://claw-bench.com\n- Repository: https://github.com/reacher-z/ClawBench\n\n## Checklist\n\n- [x] Entry is in the correct section and follows the README format.\n- [x] Links point to canonical public sources.\n- [x] No duplicate entry exists in this subsection.\n- [x] One-line factual takeaway with no marketing language.\n\n**Affiliation disclosure:** I am a maintainer/author of ClawBench.