### PR TITLE
Add OpenSkill to Self-Evolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -753,6 +753,7 @@ To make the notion of "horizon" concrete, [METR](https://arxiv.org/abs/2503.1449
 - **`arXiv 2025`** Socratic-Zero : Bootstrapping Reasoning via Data-Free Agent Co-evolution. [[paper](https://arxiv.org/abs/2509.24726)]
 - **`arXiv 2026`** Socratic-SWE: Self-Evolving Coding Agents via Trace-Derived Agent Skills. [[paper](https://arxiv.org/abs/2606.07412)]
 - **`arXiv 2025`** AgentEvolver: Towards Efficient Self-Evolving Agent System. [[paper](https://arxiv.org/abs/2511.10395)]
+- **`arXiv 2026`** OpenSkill: Open-World Self-Evolution for LLM Agents. [[paper](https://arxiv.org/abs/2606.06741)]
 
 ---
 


### PR DESCRIPTION
Adds **OpenSkill: Open-World Self-Evolution for LLM Agents** (arXiv 2606.06741) to the Self-Evolution subsection, alongside the from-zero-data / no-supervision cluster (R-Zero, Absolute Zero, Agent0, AgentEvolver).

OpenSkill: given only a task prompt, an agent acquires grounded knowledge + verification anchors from docs/repos/web, synthesizes transferable skills, and refines them against self-built virtual tasks with no target-task supervision; skills + verifier transfer across models.

Paper: https://arxiv.org/abs/2606.06741

Disclosure: I'm a co-author.